### PR TITLE
Fix docker file format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,24 +5,24 @@ MAINTAINER Mohammed A.Imran <secfigo@gmail.com>
 ENV PYTHONUNBUFFERED 1
 ENV user=bandit
 
-# install python and bandit 
-RUN echo "**** install runtime packages ****"      && \
-    apk add --no-cache py2-pip python2 bash        && \
-    echo "**** install pip packages ****"          && \
-    pip install --no-cache-dir -U pip              && \
-    pip install --no-cache-dir -U bandit           && \
-    echo "**** create volumes ****"                && \
-    mkdir -p /src                                  && \
-    mkdir -p /report                               && \
-    mkdir -p /bandit                               && \
-    echo "**** user creation ****"                 && \
-    addgroup -S bandit                             && \
-    adduser -D -S -h /src -G bandit bandit         && \
+# install python and bandit
+RUN echo "**** install runtime packages ****"       && \
+    apk add --no-cache --update py-pip python2 bash && \
+    echo "**** install pip packages ****"           && \
+    pip install --no-cache-dir -U pip               && \
+    pip install --no-cache-dir -U bandit            && \
+    echo "**** create volumes ****"                 && \
+    mkdir -p /src                                   && \
+    mkdir -p /report                                && \
+    mkdir -p /bandit                                && \
+    echo "**** user creation ****"                  && \
+    addgroup -S bandit                              && \
+    adduser -D -S -h /src -G bandit bandit          && \
     chown -R bandit:bandit /src /report /bandit
 
 USER ${user}
 
-VOLUME ["/src" "/report"]
+VOLUME ["/src", "/report"]
 
 WORKDIR /src
 


### PR DESCRIPTION
Seems like a new update has made this stop working, volumes should be
either a json string or list of mounts without comma. Due to no comma here
it is not valid JSON and perhaps parsed as the other type.

[docs](https://docs.docker.com/engine/reference/builder/#volume)

```
$ docker run --rm -it secfigo/bandit
docker: Error response from daemon: OCI runtime create failed: invalid mount {Destination:[/src Type:bind Source:/var/lib/docker/volumes/e2bf408ed0a5562147a7bc523e6851ebcf64b27b7782a46d662a035e70ef94d1/_data Options:[rbind]}: mount destination [/src not absolute: unknown.
```

also had to add `--update` to make the build work again, `py-pip` was [not found](https://stackoverflow.com/questions/44633903/alpine-package-py-pip-missing).